### PR TITLE
Store media record in variable

### DIFF
--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -49,7 +49,7 @@ class Media extends Field implements ScriptField
             $img = new $class;
             if( $img instanceof MediaProvider && $img instanceof Model ) {
                 /** @var $img MediaProvider */
-                $img->find($value);
+                $img = $img->find($value);
                 $src = $img->getThumbSrc();
                 $image = "<img src=\"{$src}\" />";
             } else {


### PR DESCRIPTION
When editing a model with a media item, the thumbnail was empty because `$img->find($value)` was not being stored in a variable. This fixes that issue.
