### PR TITLE
Allow media files to be updated

### DIFF
--- a/src/Controllers/TypeRocketMediaController.php
+++ b/src/Controllers/TypeRocketMediaController.php
@@ -132,8 +132,19 @@ class TypeRocketMediaController extends Controller
     public function update(Request $request, $id)
     {
         $tr = (object) $request->input('tr');
+        $file = $request->file('tr.file');
 
         $media = TypeRocketMedia::findOrFail($id);
+
+        if( !empty($file) ) {
+            (new LocalStorage)->down($media);
+            foreach($this->processors as $class) {
+                /** @var $imageProcess MediaProcess */
+                $imageProcess = new $class;
+                $imageProcess->run($file, $media);
+            }
+        }
+
         $media->alt = $tr->alt;
         $media->caption = $tr->caption;
         $media->save();

--- a/views/media/edit.blade.php
+++ b/views/media/edit.blade.php
@@ -27,13 +27,20 @@
                     </div>
 
                     <div class="panel-body typerocket-container">
-                        <a target="_blank" href="{{ $form->getModel()->sizes['local']['full'] }}">
-                            <img src="{{ $form->getModel()->sizes['local']['thumb'] }}?w=150&h=150" alt="{{$form->getModel()->alt}}">
-                        </a>
+                        @if(in_array(strtolower($form->getModel()->ext), ['jpg', 'png', 'gif', 'jpeg']))
+                            <a target="_blank" href="{{ $form->getModel()->sizes['local']['full'] }}">
+                                <img src="{{ $form->getModel()->sizes['local']['thumb'] }}?w=150&h=150" alt="{{$form->getModel()->alt}}">
+                            </a>
+                        @else
+                            <a target="_blank" href="{{ $form->getModel()->sizes['local']['full'] }}">
+                                {{ $form->getModel()->alt }}
+                            </a>
+                        @endif
                         <hr>
-                        {!! $form->open() !!}
+                        {!! $form->open(['enctype' => "multipart/form-data"]) !!}
                         {!! $form->text('alt')->setLabel('SEO Image Description') !!}
                         {!! $form->text('Caption')->setSetting('help', 'Used by search feature') !!}
+                        {!! $form->dropzone('file')->setLabel('Update File')->setPopulate(false) !!}
                         {!! $form->submit('Update Media') !!}
                         {!! $form->close() !!}
                     </div>

--- a/views/media/index.blade.php
+++ b/views/media/index.blade.php
@@ -62,7 +62,7 @@
                                     @endif
                                 </td>
                                 <td>
-                                    @if(in_array(strtolower($item->ext), ['jpg', 'png', 'gif', 'jpeg']))
+                                    @if(in_array(strtolower($item->ext), ['jpg', 'png', 'gif', 'jpeg', 'pdf']))
                                         <a class="btn btn-default" href="/media/{!! $item->id !!}/edit">Edit</a>
                                     @endif
                                     <form style="display: inline;"


### PR DESCRIPTION
This commit enables the edit button for pdf files and adds a file field to the media edit page. When the edit page is submitted with a file included, the old media file(s) are removed from local storage, the new file is added, and the media record is updated.